### PR TITLE
Fix UnicodeDecodeError in append_to_log for Windows-encoded log files

### DIFF
--- a/voice_assistant_streamlit.py
+++ b/voice_assistant_streamlit.py
@@ -212,11 +212,17 @@ def get_ai_response(
 def append_to_log(role: str, content: str, personality: str) -> None:
     existing = []
     if LOG_PATH.exists():
-        try:
-            with LOG_PATH.open("r", encoding="utf-8") as f:
-                existing = json.load(f)
-        except json.JSONDecodeError:
-            pass
+        # Try UTF-8 first; fall back to latin-1 for files written by Windows apps
+        # (byte 0x92 = Windows-1252 curly apostrophe, invalid in strict UTF-8)
+        for enc in ("utf-8", "latin-1"):
+            try:
+                with LOG_PATH.open("r", encoding=enc) as f:
+                    existing = json.load(f)
+                break
+            except UnicodeDecodeError:
+                continue
+            except json.JSONDecodeError:
+                break
     existing.append({
         "role": role,
         "content": content,


### PR DESCRIPTION
conversation_log.json written on Windows can contain cp1252 bytes (e.g. 0x92 curly apostrophe) that are invalid UTF-8. The except clause only caught json.JSONDecodeError, so UnicodeDecodeError crashed the app.

Now tries UTF-8 first, then falls back to latin-1 which can decode any byte sequence. All new writes remain UTF-8.

https://claude.ai/code/session_01V7reuqds72fRXijY4EGPYp