### PR TITLE
Fix ModuleNotFoundError by replacing langchain_huggingface imports

### DIFF
--- a/rag_pipeline_app.py
+++ b/rag_pipeline_app.py
@@ -8,7 +8,8 @@ from langchain_community.document_loaders import (
     UnstructuredWordDocumentLoader,
 )
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain_huggingface import HuggingFaceEmbeddings, HuggingFaceEndpoint
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.llms import HuggingFaceEndpoint
 from langchain_chroma import Chroma
 from langchain.chains import RetrievalQA
 


### PR DESCRIPTION
Replace unavailable langchain_huggingface package with equivalent imports from langchain_community.embeddings and langchain_community.llms.

https://claude.ai/code/session_01PEcqhWNuVrBAkAnADpEg3a