### PR TITLE
Fix import: langchain.text_splitter → langchain_text_splitters

### DIFF
--- a/aws_agentic_rag_app.py
+++ b/aws_agentic_rag_app.py
@@ -12,7 +12,7 @@ import streamlit as st
 from typing import TypedDict, List, Literal, Optional
 
 # ── LangChain / LangGraph ──────────────────────────────────────────────────
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import Chroma
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser


### PR DESCRIPTION
The old langchain.text_splitter path was removed in LangChain 0.2+.

https://claude.ai/code/session_018os256dnwj51KLWFmFAf1s